### PR TITLE
Add TacView log parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # DCS
+
+This repository contains Lua scripts for scoring in DCS World and a Python tool for parsing TacView logs.
+
+## tacview_stats.py
+
+`tacview_stats.py` reads TacView `.acmi` files and prints sortie and kill statistics per pilot and formation.
+
+### Usage
+
+```bash
+python tacview_stats.py <logfile>
+```
+
+Both plain text and zipped `.acmi` logs are supported. The script counts sorties, kills (air, ground, ship), refuels, CSAR pickups and friendly fire incidents.
+
+### TacView Log Format
+
+A TacView log is a comma separated text file where each line represents an object state or event. Lines starting with `#` are comments. Object lines contain fields like `Pilot`, `Group`, `Type` and `Coalition` for a specific object identifier. Event lines include an `Event` field such as `TakeOff`, `Kill` or `Refuel` referencing the object identifiers involved. The parser uses this information to build the statistics table.

--- a/tacview_stats.py
+++ b/tacview_stats.py
@@ -1,0 +1,152 @@
+import argparse
+import zipfile
+import io
+from collections import defaultdict
+
+
+def open_acmi_lines(path):
+    """Yield lines from a TacView .acmi file (plain text or zipped)."""
+    if zipfile.is_zipfile(path):
+        with zipfile.ZipFile(path) as z:
+            # read first file in archive
+            name = z.namelist()[0]
+            with z.open(name) as f:
+                for line in io.TextIOWrapper(f, encoding="utf-8", errors="ignore"):
+                    yield line
+    else:
+        with open(path, encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                yield line
+
+
+def parse_fields(line):
+    """Parse a CSV line of an ACMI file into a dict of key/value pairs.
+
+    The first token may be an object id without an explicit key. If so it will
+    be stored under ``Object``.
+    """
+
+    tokens = [t.strip() for t in line.split(',') if t.strip()]
+    fields = {}
+    if tokens and '=' not in tokens[0]:
+        fields['Object'] = tokens[0]
+        tokens = tokens[1:]
+
+    for token in tokens:
+        if '=' in token:
+            key, value = token.split('=', 1)
+            fields[key.strip()] = value.strip().strip('"')
+
+    return fields
+
+
+def categorize_type(type_str):
+    if not type_str:
+        return 'ground'
+    s = type_str.lower()
+    if 'ship' in s or 'boat' in s or 'naval' in s:
+        return 'ship'
+    if any(k in s for k in ['air', 'wing', 'heli', 'plane', 'aircraft']):
+        return 'air'
+    return 'ground'
+
+
+def update(stats, key):
+    stats[key] = stats.get(key, 0) + 1
+
+
+def parse_acmi(path):
+    objects = {}
+    pilot_stats = defaultdict(dict)
+    group_stats = defaultdict(dict)
+
+    for line in open_acmi_lines(path):
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+
+        fields = parse_fields(line)
+        if not fields:
+            continue
+
+        if 'Event' in fields:
+            event = fields['Event']
+            if event.startswith('TakeOff'):
+                oid = fields.get('Object') or fields.get('PrimaryObject')
+                obj = objects.get(oid)
+                if obj:
+                    p = obj.get('Pilot', 'Unknown')
+                    g = obj.get('Group', 'Unknown')
+                    update(pilot_stats[p], 'sorties')
+                    update(group_stats[g], 'sorties')
+            elif event == 'Kill':
+                shooter_id = fields.get('PrimaryObject') or fields.get('Object')
+                target_id = fields.get('SecondaryObject') or fields.get('Target')
+                shooter = objects.get(shooter_id)
+                target = objects.get(target_id, {})
+                if shooter:
+                    p = shooter.get('Pilot', 'Unknown')
+                    g = shooter.get('Group', 'Unknown')
+                    kill_type = categorize_type(target.get('Type'))
+                    update(pilot_stats[p], f'kill_{kill_type}')
+                    update(group_stats[g], f'kill_{kill_type}')
+                    if shooter.get('Coalition') and shooter.get('Coalition') == target.get('Coalition'):
+                        update(pilot_stats[p], 'friendly_fire')
+                        update(group_stats[g], 'friendly_fire')
+            elif event.startswith('Refuel'):
+                oid = fields.get('Object')
+                obj = objects.get(oid)
+                if obj:
+                    p = obj.get('Pilot', 'Unknown')
+                    g = obj.get('Group', 'Unknown')
+                    update(pilot_stats[p], 'refuels')
+                    update(group_stats[g], 'refuels')
+            elif event.startswith('CSAR') or event.startswith('Pickup'):
+                oid = fields.get('Object')
+                obj = objects.get(oid)
+                if obj:
+                    p = obj.get('Pilot', 'Unknown')
+                    g = obj.get('Group', 'Unknown')
+                    update(pilot_stats[p], 'csar_pickup')
+                    update(group_stats[g], 'csar_pickup')
+        else:
+            oid = fields.get('Object') or fields.get('ID')
+            if oid:
+                existing = objects.setdefault(oid, {})
+                existing.update(fields)
+
+    return pilot_stats, group_stats
+
+
+def print_table(title, stats):
+    headers = ['Sorties', 'KillAir', 'KillGround', 'KillShip', 'Refuel', 'CSAR', 'FF']
+    print(title)
+    print('{:20s} '.format('Name') + ' '.join('{:9s}'.format(h) for h in headers))
+    print('-' * 20 + ' ' + ' '.join(['-'*9 for _ in headers]))
+    for name, data in sorted(stats.items()):
+        row = [
+            data.get('sorties', 0),
+            data.get('kill_air', 0),
+            data.get('kill_ground', 0),
+            data.get('kill_ship', 0),
+            data.get('refuels', 0),
+            data.get('csar_pickup', 0),
+            data.get('friendly_fire', 0)
+        ]
+        print('{:20s} '.format(name) + ' '.join('{:9d}'.format(int(x)) for x in row))
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='TacView ACMI statistics')
+    parser.add_argument('logfile', help='Path to .acmi log file')
+    args = parser.parse_args()
+
+    pilot_stats, group_stats = parse_acmi(args.logfile)
+
+    print_table('Pilot stats', pilot_stats)
+    print_table('Group stats', group_stats)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- create `tacview_stats.py` utility
- support zipped or plain `.acmi` log files
- parse events and object data to generate sortie/kills statistics
- document usage in README

## Testing
- `python -m py_compile tacview_stats.py`
